### PR TITLE
Fix bug with getting sequential model layers; Add compatability for R >3.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Description: Visualize neural net architectures using the 'ggraph' and 'Diagramm
     Creates and plots a graph using the layer and node information.
 URL: https://github.com/andrie/deepviz, https://andrie.github.io/deepviz/index.html
 BugReports: https://github.com/andrie/deepviz/issues
-Depends: R (>= 3.5)
+Depends: R (>= 3.4)
 License: MIT + file LICENSE
 Suggests: 
     rmarkdown,

--- a/R/model_nodes.R
+++ b/R/model_nodes.R
@@ -6,7 +6,9 @@
 model_nodes <- function(x){
   assert_that(is.keras_model(x))
   if (is.keras_model_sequential(x)) {
-    model_layers <- x$get_config()$layers
+    # Before the CRAN release of keras on 4-5-2019,
+    # this was x$get_config()$layers
+    model_layers <- x$get_config()
     l_name <- map_chr(model_layers, ~purrr::pluck(., "config", "name"))
   } else {
     model_layers <- x$get_config()$layers
@@ -28,4 +30,3 @@ model_nodes <- function(x){
     activation = l_activation
   )
 }
-

--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ Add some more layers and plot
 
 ``` r
 model <- keras_model_sequential() %>%
-  layer_conv_2d(filters = 16, kernel_size = c(3, 3)) %>% 
-  layer_max_pooling_2d() %>% 
+  layer_conv_2d(filters = 16, kernel_size = c(3, 3)) %>%
+  layer_max_pooling_2d() %>%
   layer_dense(10, input_shape = 4) %>%
   layer_dense(10, input_shape = 4) %>%
-  layer_dropout(0.25) %>% 
+  layer_dropout(0.25) %>%
   layer_dense(2, activation = "sigmoid")
 
 model %>% plot_model()
@@ -70,7 +70,7 @@ model %>% plot_model()
 
 ## plot\_model() with network models
 
-Construct a network model using the `keras` function API, using the
+Construct a network model using the `keras` functional API, using the
 example from <https://keras.rstudio.com/articles/functional_api.html>
 
 ``` r
@@ -101,28 +101,28 @@ model <- local({
 model
 #> Model
 #> ___________________________________________________________________________
-#> Layer (type)            Output Shape     Param #  Connected to             
+#> Layer (type)            Output Shape     Param #  Connected to
 #> ===========================================================================
-#> main_input (InputLayer) (None, 100)      0                                 
+#> main_input (InputLayer) (None, 100)      0
 #> ___________________________________________________________________________
-#> embedding_1 (Embedding) (None, 100, 512) 5120000  main_input[0][0]         
+#> embedding_1 (Embedding) (None, 100, 512) 5120000  main_input[0][0]
 #> ___________________________________________________________________________
-#> lstm_1 (LSTM)           (None, 32)       69760    embedding_1[0][0]        
+#> lstm_1 (LSTM)           (None, 32)       69760    embedding_1[0][0]
 #> ___________________________________________________________________________
-#> aux_input (InputLayer)  (None, 5)        0                                 
+#> aux_input (InputLayer)  (None, 5)        0
 #> ___________________________________________________________________________
-#> concatenate_1 (Concaten (None, 37)       0        lstm_1[0][0]             
-#>                                                   aux_input[0][0]          
+#> concatenate_1 (Concaten (None, 37)       0        lstm_1[0][0]
+#>                                                   aux_input[0][0]
 #> ___________________________________________________________________________
-#> dense_6 (Dense)         (None, 64)       2432     concatenate_1[0][0]      
+#> dense_6 (Dense)         (None, 64)       2432     concatenate_1[0][0]
 #> ___________________________________________________________________________
-#> dense_7 (Dense)         (None, 64)       4160     dense_6[0][0]            
+#> dense_7 (Dense)         (None, 64)       4160     dense_6[0][0]
 #> ___________________________________________________________________________
-#> dense_8 (Dense)         (None, 64)       4160     dense_7[0][0]            
+#> dense_8 (Dense)         (None, 64)       4160     dense_7[0][0]
 #> ___________________________________________________________________________
-#> main_output (Dense)     (None, 1)        65       dense_8[0][0]            
+#> main_output (Dense)     (None, 1)        65       dense_8[0][0]
 #> ___________________________________________________________________________
-#> aux_output (Dense)      (None, 1)        33       lstm_1[0][0]             
+#> aux_output (Dense)      (None, 1)        33       lstm_1[0][0]
 #> ===========================================================================
 #> Total params: 5,200,610
 #> Trainable params: 5,200,610
@@ -143,7 +143,7 @@ model %>% plot_model()
 ### Logistic regression:
 
 ``` r
-c(4, 1) %>% 
+c(4, 1) %>%
   plot_deepviz()
 ```
 
@@ -152,7 +152,7 @@ c(4, 1) %>%
 ### One hidden layer:
 
 ``` r
-c(4, 10, 1) %>% 
+c(4, 10, 1) %>%
   plot_deepviz()
 ```
 
@@ -161,7 +161,7 @@ c(4, 10, 1) %>%
 ### A multi-layer perceptron (two hidden layers):
 
 ``` r
-c(4, 10, 10, 1) %>% 
+c(4, 10, 10, 1) %>%
   plot_deepviz()
 ```
 
@@ -170,7 +170,7 @@ c(4, 10, 10, 1) %>%
 ### Multi-class classification
 
 ``` r
-c(4, 10, 10, 3) %>% 
+c(4, 10, 10, 3) %>%
   plot_deepviz()
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ model %>% plot_model()
 
 <img src="man/figures/README-webshot-1-1.png" width="100%" />
 
-Saving the model requires using `webshot`.  See [Readme.Rmd](Readme.Rmd) for an example.
+Saving the model requires using `webshot`.  See [README.Rmd](README.Rmd) for an example.
 
 Add some more layers and plot
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ model %>% plot_model()
 
 <img src="man/figures/README-webshot-1-1.png" width="100%" />
 
+Saving the model requires using `webshot`.  See [Readme.Rmd](Readme.Rmd) for an example.
+
 Add some more layers and plot
 
 ``` r


### PR DESCRIPTION
This fixes the bug introduced by the newest version of `keras` on CRAN where model layers are accessed via `model$get_config()` now instead of `model$get_config()$layers`.  It also lowers the R version requirement to 3.4 for base Ubuntu users.   Addresses #12 